### PR TITLE
Use minlength / maxlength attributes for Length validator rendering.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ MANIFEST
 dist/
 build/
 misc/
+venv/
+.vscode/

--- a/tests/test_autoattrmeta.py
+++ b/tests/test_autoattrmeta.py
@@ -12,6 +12,7 @@ from unittest import TestCase
 from wtforms.validators import (
     InputRequired,
     Length,
+    NumberRange,
 )
 
 from . import (
@@ -40,20 +41,37 @@ class TestMeta(TestCase):
 
     def test_minmax(self):
         # min
-        form = get_form(validators=[Length(min=3), ], use_meta=True)
+        form = get_form(validators=[NumberRange(min=3), ], use_meta=True)
         field = get_field(form)
         self.assertEqual(field.attrs['min'], '3')
         self.assertNotIn('max', field.attrs)
         # max
-        form = get_form(validators=[Length(max=8), ], use_meta=True)
+        form = get_form(validators=[NumberRange(max=8), ], use_meta=True)
         field = get_field(form)
         self.assertEqual(field.attrs['max'], '8')
         self.assertNotIn('min', field.attrs)
         # min + max
-        form = get_form(validators=[Length(min=3, max=8), ], use_meta=True)
+        form = get_form(validators=[NumberRange(min=3, max=8), ], use_meta=True)
         field = get_field(form)
         self.assertEqual(field.attrs['min'], '3')
         self.assertEqual(field.attrs['max'], '8')
+
+    def test_minmaxlength(self):
+        # min
+        form = get_form(validators=[Length(min=3), ], use_meta=True)
+        field = get_field(form)
+        self.assertEqual(field.attrs['minlength'], '3')
+        self.assertNotIn('maxlength', field.attrs)
+        # max
+        form = get_form(validators=[Length(max=8), ], use_meta=True)
+        field = get_field(form)
+        self.assertEqual(field.attrs['maxlength'], '8')
+        self.assertNotIn('minlength', field.attrs)
+        # min + max
+        form = get_form(validators=[Length(min=3, max=8), ], use_meta=True)
+        field = get_field(form)
+        self.assertEqual(field.attrs['minlength'], '3')
+        self.assertEqual(field.attrs['maxlength'], '8')
 
     def test_title(self):
         form = get_form(description='Some help text', use_meta=True)

--- a/tests/test_get_html5_kwargs.py
+++ b/tests/test_get_html5_kwargs.py
@@ -19,6 +19,7 @@ from wtforms.validators import (
 
 from wtforms_html5 import (
     MINMAX_VALIDATORS,
+    MINMAXLENGTH_VALIDATORS,
     get_html5_kwargs,
 )
 
@@ -140,7 +141,7 @@ class TestGetHtml5Kwargs(TestCase):
         self.assertTrue(form.validate())
         res = get_html5_kwargs(form.test_field)
         exp = {
-            'min': 5,
+            'minlength': 5,
         }
         self.assertEqual(res, exp)
         # invalid input
@@ -152,7 +153,7 @@ class TestGetHtml5Kwargs(TestCase):
         res = get_html5_kwargs(form.test_field)
         exp = {
             'class': 'invalid',
-            'min': 5,
+            'minlength': 5,
         }
         self.assertEqual(res, exp)
 
@@ -166,7 +167,7 @@ class TestGetHtml5Kwargs(TestCase):
         res = get_html5_kwargs(form.test_field, {'class': 'test'})
         exp = {
             'class': 'invalid test',
-            'min': 5,
+            'minlength': 5,
         }
         self.assertEqual(res, exp)
         # add to class_
@@ -178,7 +179,7 @@ class TestGetHtml5Kwargs(TestCase):
         res = get_html5_kwargs(form.test_field, {'class_': 'test zwo'})
         exp = {
             'class': 'invalid test zwo',
-            'min': 5,
+            'minlength': 5,
         }
         self.assertEqual(res, exp)
 
@@ -229,6 +230,57 @@ class TestGetHtml5Kwargs(TestCase):
                 res = get_html5_kwargs(form.test_field, render_kw)
                 self.assertEqual(res, exp)
                 # min + max
+                form = get_form(validators=[Validator(max=5, min=2)])
+                res = get_html5_kwargs(form.test_field, render_kw)
+                self.assertEqual(res, exp)
+
+
+    @SkipIfNoSubtests
+    def test_auto_minmaxlength(self):
+        for Validator in MINMAXLENGTH_VALIDATORS:
+            with self.subTest(Validator=Validator):
+                # minlength
+                form = get_form(validators=[Validator(min=5)])
+                res = get_html5_kwargs(form.test_field)
+                exp = {
+                    'minlength': 5,
+                }
+                self.assertEqual(res, exp)
+                # maxlength
+                form = get_form(validators=[Validator(max=5)])
+                res = get_html5_kwargs(form.test_field)
+                exp = {
+                    'maxlength': 5,
+                }
+                self.assertEqual(res, exp)
+                # minlength + maxlength
+                form = get_form(validators=[Validator(max=5, min=2)])
+                res = get_html5_kwargs(form.test_field)
+                exp = {
+                    'minlength': 2,
+                    'maxlength': 5,
+                }
+                self.assertEqual(res, exp)
+
+
+    @SkipIfNoSubtests
+    def test_auto_minmaxlength_no_overwrite(self):
+        render_kw = {
+            'minlength': 10,
+            'maxlength': 20,
+        }
+        exp = render_kw.copy()
+        for Validator in MINMAXLENGTH_VALIDATORS:
+            with self.subTest(Validator=Validator):
+                # minlength
+                form = get_form(validators=[Validator(min=5)])
+                res = get_html5_kwargs(form.test_field, render_kw)
+                self.assertEqual(res, exp)
+                # maxlength
+                form = get_form(validators=[Validator(max=5)])
+                res = get_html5_kwargs(form.test_field, render_kw)
+                self.assertEqual(res, exp)
+                # minlength + maxlength
                 form = get_form(validators=[Validator(max=5, min=2)])
                 res = get_html5_kwargs(form.test_field, render_kw)
                 self.assertEqual(res, exp)

--- a/wtforms_html5.py
+++ b/wtforms_html5.py
@@ -116,8 +116,11 @@ __license__ = 'GNU General Public License v3 or above - '\
 
 
 MINMAX_VALIDATORS = (
-    Length,
     NumberRange,
+)
+
+MINMAXLENGTH_VALIDATORS = (
+    Length,
 )
 
 
@@ -190,6 +193,38 @@ def set_minmax(field, render_kw=None, force=False):
     return render_kw
 
 
+def set_minmaxlength(field, render_kw=None, force=False):
+    """
+    Returns *render_kw* with *minlength* and *maxlength* set if validators use
+    them.
+
+    Sets *minlength* and / or *maxlength* keys if there is a `Length` validator
+    present and the corresponding parameters (i.e. `min` or `max`) are set.
+
+    ..note::
+
+        This won't change keys already present unless *force* is used.
+
+    """
+    if render_kw is None:
+        render_kw = {}
+    for validator in field.validators:
+        if isinstance(validator, MINMAXLENGTH_VALIDATORS):
+            if 'minlength' not in render_kw or force:
+                v_min = getattr(validator, 'min', -1)
+                if v_min not in (-1, None):
+                    render_kw['minlength'] = v_min
+            if 'maxlength' not in render_kw or force:
+                v_max = getattr(validator, 'max', -1)
+                if v_max not in (-1, None):
+                    render_kw['maxlength'] = v_max
+            # Inconsistency: Length validator uses min and max for specifying
+            #                length limits while HTML5 uses minlength and
+            #                maxlength (attributes of input element) for the
+            #                same purpose.
+    return render_kw
+
+
 def set_title(field, render_kw=None):
     """
     Returns *render_kw* with *min* and *max* set if required.
@@ -250,6 +285,7 @@ def get_html5_kwargs(field, render_kw=None, force=False):
     kwargs = set_required(field, kwargs, force)  # is field required?
     kwargs = set_invalid(field, kwargs)  # is field invalid?
     kwargs = set_minmax(field, kwargs, force)  # check validators for min/max
+    kwargs = set_minmaxlength(field, kwargs, force)  # check validators for minlength/maxlength
     kwargs = set_title(field, kwargs)  # missing tile?
     return kwargs
 

--- a/wtforms_html5.py
+++ b/wtforms_html5.py
@@ -69,8 +69,8 @@ fields of the form:
 
 >>> f = form.test_field()
 >>> exp = (
-...  '<input id="test_field" max="12" min="3" name="test_field" required '
-...  'title="Just a test field." type="text" value="">'
+...  '<input id="test_field" maxlength="12" minlength="3" name="test_field" '
+...  'required title="Just a test field." type="text" value="">'
 ... )
 >>> assert f == exp
 
@@ -86,7 +86,7 @@ added to its class:
 >>> form.validate()
 False
 >>> exp = (
-... '<input class="invalid" id="test_field" max="12" min="3" '
+... '<input class="invalid" id="test_field" maxlength="12" minlength="3" '
 ... 'name="test_field" required title="Just a test field." type="text" '
 ... 'value="">'
 ... )
@@ -285,7 +285,8 @@ def get_html5_kwargs(field, render_kw=None, force=False):
     kwargs = set_required(field, kwargs, force)  # is field required?
     kwargs = set_invalid(field, kwargs)  # is field invalid?
     kwargs = set_minmax(field, kwargs, force)  # check validators for min/max
-    kwargs = set_minmaxlength(field, kwargs, force)  # check validators for minlength/maxlength
+    kwargs = set_minmaxlength(field, kwargs, force)
+    # check validators for minlength/maxlength
     kwargs = set_title(field, kwargs)  # missing tile?
     return kwargs
 


### PR DESCRIPTION
Max / min attributes for `<input>` in HTML5 seems to work only for numeric / date / time fields. For validating the length of a field value, `maxlength` / `minlength` behave as intended.